### PR TITLE
Update python dependencies to currently available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 
 # use bash for pushd/popd, and to fail quickly. virtualenv's activate
 # has undefined variables, so no -u
-SHELL = bash -e -o pipefail
+SHELL = bash -eu -o pipefail
 
 # You can set these variables from the command line.
-SPHINXOPTS   ?= 
+SPHINXOPTS   ?=
 SPHINXBUILD  ?= sphinx-build
 SOURCEDIR    ?= .
 BUILDDIR     ?= _build
@@ -45,5 +45,5 @@ clean-all: clean
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: $(VIRTUALENV) Makefile
-	source ./$</bin/activate ; set -u;\
+	source ./$</bin/activate ;\
   $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/README.rst
+++ b/README.rst
@@ -8,14 +8,14 @@ About The Book
   :alt: written by humans not by AI button
   :target: https://notbyai.fyi
 
-.. image:: https://github.com/SystemsApproach/ops/actions/workflows/publish-docs.yaml/badge.svg
-  :align: left
-  :alt: deployment status button
-  :target: https://github.com/SystemsApproach/ops/actions/
+.. only:: html
 
+  .. image:: https://github.com/SystemsApproach/ops/actions/workflows/publish-docs.yaml/badge.svg
+    :align: left
+    :alt: deployment status button
+    :target: https://github.com/SystemsApproach/ops/actions/
 
 |
-
 
 Source for *Edge Cloud Operations: A Systems Approach* is available on
 GitHub under

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
-Sphinx~=5.3.0
-doc8~=0.10.1
-docutils~=0.17.1
-reuse~=0.14.0
-sphinx-rtd-theme~=1.0.0
-sphinxcontrib-spelling~=7.3.2
+Sphinx~=8.2.3
+doc8~=2.0.0
+reuse~=5.0.2
+sphinx-rtd-theme~=3.0.2
+sphinxcontrib-spelling~=8.0.1
 sphinx-multiversion~=0.2.4
-pytz~=2023.3


### PR DESCRIPTION
- Remove indirect dependencies
- Only display github build status svg banner in README.rst in HTML output (otherwise `make latexpdf` build fails)
- Makefile cleanup